### PR TITLE
feat: add local start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,13 @@ This project is based on [OpenSaas](https://opensaas.sh) template and consists o
 3. `blog` - Your blog / docs, built with [Astro](https://docs.astro.build) based on [Starlight](https://starlight.astro.build/) template.
 
 For more details, check READMEs of each respective directory!
+
+## Running locally
+
+Start the application, gateway and dashboard with a single command:
+
+```bash
+npm run dev
+```
+
+This script expects the required `.env` files and a local [Wasp](https://wasp.sh) installation.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "scripts": {
+    "dev": "./start-local.sh",
     "test": "node --loader ts-node/esm --test tests/*.test.ts"
   },
   "devDependencies": {

--- a/start-local.sh
+++ b/start-local.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Start Wasp database
+(cd app && wasp start db) &
+APP_DB_PID=$!
+
+# Start Wasp app
+(cd app && wasp start) &
+APP_PID=$!
+
+# Start gateway service
+(cd gateway && npm run dev) &
+GATEWAY_PID=$!
+
+# Start dashboard
+(cd dashboard && npm run dev) &
+DASHBOARD_PID=$!
+
+# Ensure all subprocesses are terminated on exit
+trap "kill $APP_DB_PID $APP_PID $GATEWAY_PID $DASHBOARD_PID" EXIT
+
+wait


### PR DESCRIPTION
## Summary
- add `start-local.sh` script to launch app db, app, gateway and dashboard together
- expose the script via `npm run dev` and document usage in README

## Testing
- `npm test` *(fails: Error [ERR_REQUIRE_CYCLE_MODULE])*

------
https://chatgpt.com/codex/tasks/task_e_68b20753c56883308ced282267b8ba39